### PR TITLE
Add a check for existence of "for"

### DIFF
--- a/lib/build-command.js
+++ b/lib/build-command.js
@@ -8,7 +8,7 @@ module.exports = function buildCommand ({name, type, locatorTemplate, labelTempl
         log: false,
         timeout: options.wait
       }).and($el => {
-        if (labelTemplate && $el && $el.is('label')) {
+        if (labelTemplate && $el && $el.is('label') && $el.attr('for')) {
           return cy.get(labelTemplate.format({id: $el.attr('for')}))
         } else {
           return $el


### PR DESCRIPTION
If there is no "for" selector found, then we must be in the case of a label wrapping the input + some text.

```html
<label>
  <input type="checkbox" />
  Some label text
</label>
```
in this case we usually want to click / interact with the label itself.

This is a rather quick fix, for something more elaborate we might want to find the actual input itself, but its better than the current implementation.