### PR TITLE
Support "[role=button]" style as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ module.exports = {
         input[type=image][id="${'locator'}"],
         input[type=button][title*="${'locator'}"],
         input[type=button][value*="${'locator'}"],
-        input[type=button][id="${'locator'}"]
+        input[type=button][id="${'locator'}"],
+        *[role=button]:contains("${'locator'}")
       `
     })
   ]


### PR DESCRIPTION
Material UI has a tendency to use divs and spans, instead of proper semantic html for some reason. But they are careful to add role=button to things that should act as buttons.
Since this is in the spirit of what the selector wants to target, maybe its worth adding it here?