### PR TITLE
Use .then rather than .and for utilizing labelTemplate

### DIFF
--- a/lib/build-command.js
+++ b/lib/build-command.js
@@ -7,7 +7,7 @@ module.exports = function buildCommand ({name, type, locatorTemplate, labelTempl
       return cy.get(selector, {
         log: false,
         timeout: options.wait
-      }).and($el => {
+      }).then($el => {
         if (labelTemplate && $el && $el.is('label') && $el.attr('for')) {
           return cy.get(labelTemplate.format({id: $el.attr('for')}))
         } else {


### PR DESCRIPTION
Please see https://docs.cypress.io/api/commands/should#Differences for reasoning. It looks like an assertion is not being made here and that we are further selecting to a more specific dom element. This seems like a use case for .then. Making this change makes cypress-capybara work better for my project test where I'm toggling button states.