### PR TITLE
Revert "Use .then rather than .and for utilizing labelTemplate"

### DIFF
--- a/lib/build-command.js
+++ b/lib/build-command.js
@@ -7,7 +7,7 @@ module.exports = function buildCommand ({name, type, locatorTemplate, labelTempl
       return cy.get(selector, {
         log: false,
         timeout: options.wait
-      }).then($el => {
+      }).and($el => {
         if (labelTemplate && $el && $el.is('label') && $el.attr('for')) {
           return cy.get(labelTemplate.format({id: $el.attr('for')}))
         } else {


### PR DESCRIPTION
Reverts testdouble/cypress-capybara#6.

Somehow this change breaks negative expectation tests that you have set up. Specifically the `.should('not.exist')` ones. I tried figuring out why but it's still mysterious to me. For now this should be reverted.